### PR TITLE
Correction to CRMsummary.dat formatting

### DIFF
--- a/crm.pl
+++ b/crm.pl
@@ -249,7 +249,7 @@ $txt .= sprintf "           External Proton Flux (p/cm^2-s-sr-MeV) : %.4e\n",$fl
 $txt .= sprintf "         Attenuated Proton Flux (p/cm^2-s-sr-MeV) : %.4e\n",$aflux;
 $txt .= sprintf "  External Proton Orbital Fluence (p/cm^2-sr-MeV) : %.4e\n",$fluence;
 $txt .= sprintf "Attenuated Proton Orbital Fluence (p/cm^2-sr-MeV) : %.4e\n",$afluence;
-$txt .= sprintf "\n";
+#$txt .= sprintf "\n";
 #$txt .= sprintf "Due to transition to GOES-16, what used to be P2 is now P4 and what used to be P5 is now P7\n";
 #$txt .= sprintf "This message will dissappear in 01/31/2021\n";
 


### PR DESCRIPTION
This PR is a minor correction to the perl script generating the CRMsummary.dat data file. In Chandra snapshot, the snap.pm library reads this file in order to format the f_CRM data value in the chandra.snapshot text file.

[Data Fetch Line](https://github.com/chandra-mta/snapshot/blob/f636168d6bbd399ff981343fa1d0250e6a0259c9/snap.pm#L171)

The processing of this text file when the last line is only a newline character results in the perl sprintf formatting function reading in an `undef` value, and as such will display the f_CRM values as zero, even though the correct data value is available.

This correction causes the last line of the CRMsummary.dat file to be the `Attenuated Proton Orbital Fluence` value, thus allowing snap.pm to read the correct value.